### PR TITLE
Fix naming: doesntEmpty -> isNotEmpty

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,6 +1,6 @@
 name: phpunit
 
-on: [ push ]
+on: [ push, pull_request ]
 
 permissions: read-all
 

--- a/src/Helpers/Str.php
+++ b/src/Helpers/Str.php
@@ -521,19 +521,19 @@ class Str
 
     /**
      * @deprecated
-     * @see self::isntEmpty()
+     * @see self::isNotEmpty()
      *
      * Determines if the value is doesn't empty.
      */
     public function doesntEmpty(mixed $value): bool
     {
-        return $this->isntEmpty($value);
+        return $this->isNotEmpty($value);
     }
 
     /**
      * Determines if the value isn't empty.
      */
-    public function isntEmpty(mixed $value): bool
+    public function isNotEmpty(mixed $value): bool
     {
         return ! $this->isEmpty($value);
     }

--- a/src/Helpers/Str.php
+++ b/src/Helpers/Str.php
@@ -520,9 +520,20 @@ class Str
     }
 
     /**
+     * @deprecated
+     * @see self::isntEmpty()
+     *
      * Determines if the value is doesn't empty.
      */
     public function doesntEmpty(mixed $value): bool
+    {
+        return $this->isntEmpty($value);
+    }
+
+    /**
+     * Determines if the value isn't empty.
+     */
+    public function isntEmpty(mixed $value): bool
     {
         return ! $this->isEmpty($value);
     }


### PR DESCRIPTION
This PR creates new method called **isntEmpty**, which uses the same logic as method **doesntEmpty**. Gramatically, doesntEmpty is not correct, therefore it is also not intuitive (why have one method named isEmpty and the opposite named doesntEmpty).

The original method _doesntEmpty_ still exists (to ensure backwards-compatibility), but is deprecated.

I understand that this is not an important change, but I feel like it is something that _could_ be changed.