### PR TITLE
Remove redundant symfony/polyfill-php81 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
         "ext-mbstring": "*",
         "dragon-code/contracts": "^2.22.0",
         "psr/http-message": "^1.0.1 || ^2.0",
-        "symfony/polyfill-php81": "^1.25",
         "voku/portable-ascii": "^1.4.8 || ^2.0.1"
     },
     "require-dev": {


### PR DESCRIPTION
This package depends on `symfony/polyfill-php81`, but also `php: ^8.1`, so the polyfill requirement doesn't seem necessary anymore?